### PR TITLE
[DEV-72] Bugfix: fluxo da carteira iOS - v2

### DIFF
--- a/IngresseSDK.xcodeproj/project.pbxproj
+++ b/IngresseSDK.xcodeproj/project.pbxproj
@@ -15,6 +15,18 @@
 		2F7D2F8B22EFA1AA00DD8E17 /* UserWalletInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7D2F8A22EFA1AA00DD8E17 /* UserWalletInfo.swift */; };
 		2F7D2F8D22EFAC2B00DD8E17 /* WalletInfoPaypal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7D2F8C22EFAC2B00DD8E17 /* WalletInfoPaypal.swift */; };
 		2F7D2F8F22EFAC8000DD8E17 /* WalletInfoCreditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7D2F8E22EFAC8000DD8E17 /* WalletInfoCreditCard.swift */; };
+		2FA9C3D8255DC9B600ACBD9D /* UserWalletURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3D7255DC9B600ACBD9D /* UserWalletURLRequest.swift */; };
+		2FA9C3DD255DD2BE00ACBD9D /* WalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3DC255DD2BE00ACBD9D /* WalletRequest.swift */; };
+		2FA9C3E1255DD44F00ACBD9D /* UserWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3E0255DD44F00ACBD9D /* UserWalletService.swift */; };
+		2FA9C3E7255DD9FB00ACBD9D /* KeyedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3E6255DD9FB00ACBD9D /* KeyedRequest.swift */; };
+		2FA9C3ED255E0BCE00ACBD9D /* IngresseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3EC255E0BCE00ACBD9D /* IngresseResponse.swift */; };
+		2FA9C3F8255E153000ACBD9D /* IngresseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3F7255E153000ACBD9D /* IngresseError.swift */; };
+		2FA9C3FD255F109A00ACBD9D /* ResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3FC255F109A00ACBD9D /* ResponseError.swift */; };
+		2FA9C405255F3E5B00ACBD9D /* PagedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C404255F3E5B00ACBD9D /* PagedResponse.swift */; };
+		2FA9C40B255F40D200ACBD9D /* UserWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C40A255F40D200ACBD9D /* UserWallet.swift */; };
+		2FA9C40F255F458500ACBD9D /* UserWallet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C40E255F458400ACBD9D /* UserWallet+Extensions.swift */; };
+		2FA9C4EB256352AB00ACBD9D /* ApiResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C4EA256352AB00ACBD9D /* ApiResult.swift */; };
+		2FA9C4F22563569500ACBD9D /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C4F12563569500ACBD9D /* Errors.swift */; };
 		2FC7448923D6291A000C1430 /* Insurance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC7448823D6291A000C1430 /* Insurance.swift */; };
 		2FCD56EE255CAD350085D533 /* WalletEventCashless.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCD56ED255CAD350085D533 /* WalletEventCashless.swift */; };
 		2FEAF87E235A20CF0080D1BA /* PhoneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEAF87D235A20CF0080D1BA /* PhoneService.swift */; };
@@ -228,6 +240,18 @@
 		2F7D2F8A22EFA1AA00DD8E17 /* UserWalletInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletInfo.swift; sourceTree = "<group>"; };
 		2F7D2F8C22EFAC2B00DD8E17 /* WalletInfoPaypal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfoPaypal.swift; sourceTree = "<group>"; };
 		2F7D2F8E22EFAC8000DD8E17 /* WalletInfoCreditCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfoCreditCard.swift; sourceTree = "<group>"; };
+		2FA9C3D7255DC9B600ACBD9D /* UserWalletURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletURLRequest.swift; sourceTree = "<group>"; };
+		2FA9C3DC255DD2BE00ACBD9D /* WalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRequest.swift; sourceTree = "<group>"; };
+		2FA9C3E0255DD44F00ACBD9D /* UserWalletService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletService.swift; sourceTree = "<group>"; };
+		2FA9C3E6255DD9FB00ACBD9D /* KeyedRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedRequest.swift; sourceTree = "<group>"; };
+		2FA9C3EC255E0BCE00ACBD9D /* IngresseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngresseResponse.swift; sourceTree = "<group>"; };
+		2FA9C3F7255E153000ACBD9D /* IngresseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngresseError.swift; sourceTree = "<group>"; };
+		2FA9C3FC255F109A00ACBD9D /* ResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseError.swift; sourceTree = "<group>"; };
+		2FA9C404255F3E5B00ACBD9D /* PagedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedResponse.swift; sourceTree = "<group>"; };
+		2FA9C40A255F40D200ACBD9D /* UserWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWallet.swift; sourceTree = "<group>"; };
+		2FA9C40E255F458400ACBD9D /* UserWallet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserWallet+Extensions.swift"; sourceTree = "<group>"; };
+		2FA9C4EA256352AB00ACBD9D /* ApiResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiResult.swift; sourceTree = "<group>"; };
+		2FA9C4F12563569500ACBD9D /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		2FC7448823D6291A000C1430 /* Insurance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Insurance.swift; sourceTree = "<group>"; };
 		2FCD56ED255CAD350085D533 /* WalletEventCashless.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletEventCashless.swift; sourceTree = "<group>"; };
 		2FEAF87D235A20CF0080D1BA /* PhoneService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneService.swift; sourceTree = "<group>"; };
@@ -459,6 +483,85 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		2FA9C3D6255DC57100ACBD9D /* UserWallet */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C3EA255E0B9200ACBD9D /* Responses */,
+				2FA9C3DB255DD2AA00ACBD9D /* Requests */,
+				2FA9C3D7255DC9B600ACBD9D /* UserWalletURLRequest.swift */,
+				2FA9C3E0255DD44F00ACBD9D /* UserWalletService.swift */,
+			);
+			path = UserWallet;
+			sourceTree = "<group>";
+		};
+		2FA9C3DB255DD2AA00ACBD9D /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C3DC255DD2BE00ACBD9D /* WalletRequest.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		2FA9C3E4255DD9D600ACBD9D /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C3EB255E0BA000ACBD9D /* Responses */,
+				2FA9C3E5255DD9ED00ACBD9D /* Requests */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		2FA9C3E5255DD9ED00ACBD9D /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C3E6255DD9FB00ACBD9D /* KeyedRequest.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		2FA9C3EA255E0B9200ACBD9D /* Responses */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C40A255F40D200ACBD9D /* UserWallet.swift */,
+				2FA9C40E255F458400ACBD9D /* UserWallet+Extensions.swift */,
+			);
+			path = Responses;
+			sourceTree = "<group>";
+		};
+		2FA9C3EB255E0BA000ACBD9D /* Responses */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C3EC255E0BCE00ACBD9D /* IngresseResponse.swift */,
+				2FA9C3F7255E153000ACBD9D /* IngresseError.swift */,
+				2FA9C404255F3E5B00ACBD9D /* PagedResponse.swift */,
+			);
+			path = Responses;
+			sourceTree = "<group>";
+		};
+		2FA9C3FB255F108700ACBD9D /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C3FC255F109A00ACBD9D /* ResponseError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
+		2FA9C4E92563528B00ACBD9D /* Parser */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C4EA256352AB00ACBD9D /* ApiResult.swift */,
+			);
+			path = Parser;
+			sourceTree = "<group>";
+		};
+		2FA9C4F02563567F00ACBD9D /* Defaults */ = {
+			isa = PBXGroup;
+			children = (
+				2FA9C4F12563569500ACBD9D /* Errors.swift */,
+			);
+			path = Defaults;
+			sourceTree = "<group>";
+		};
 		352A26B321A590F80037E187 /* Requests */ = {
 			isa = PBXGroup;
 			children = (
@@ -477,6 +580,9 @@
 		598CD3F0245645AE00D16220 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				2FA9C4F02563567F00ACBD9D /* Defaults */,
+				2FA9C4E92563528B00ACBD9D /* Parser */,
+				2FA9C3FB255F108700ACBD9D /* Error */,
 				598CD3F1245645AE00D16220 /* Network.swift */,
 				598CD3F4245645AE00D16220 /* NetworkURLRequest.swift */,
 				598CD3F2245645AE00D16220 /* Authorization */,
@@ -547,6 +653,7 @@
 		624525F91EC23217007B6584 /* IngresseSDK */ = {
 			isa = PBXGroup;
 			children = (
+				2FA9C3E4255DD9D600ACBD9D /* Base */,
 				624525FA1EC23217007B6584 /* IngresseSDK.h */,
 				CEEBC6E6246C4DF900D87A81 /* Extensions */,
 				624526111EC2322C007B6584 /* Errors */,
@@ -683,6 +790,7 @@
 		6245262D1EC23255007B6584 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				2FA9C3D6255DC57100ACBD9D /* UserWallet */,
 				352A167B2110A80900814AF9 /* AddressService.swift */,
 				6245262E1EC23255007B6584 /* AuthService.swift */,
 				6294D6E71F7279F90064EBFA /* BaseService.swift */,
@@ -1100,6 +1208,7 @@
 				69AE6D6D2368C58400C8FE22 /* DeclinedReason.swift in Sources */,
 				624526331EC23255007B6584 /* AuthService.swift in Sources */,
 				62BFE06F1F72A82B007150ED /* TransferTicket.swift in Sources */,
+				2FA9C3FD255F109A00ACBD9D /* ResponseError.swift in Sources */,
 				62E134E11F20FBA70007B590 /* PaymentType.swift in Sources */,
 				6245261F1EC2323E007B6584 /* IngresseClient.swift in Sources */,
 				627485581F054776009AE812 /* TransactionService.swift in Sources */,
@@ -1129,8 +1238,10 @@
 				624526211EC2323E007B6584 /* RestClientInterface.swift in Sources */,
 				2FEAF888235A4DE10080D1BA /* PhoneDDI.swift in Sources */,
 				35376BF0215041270072C21E /* UpdatedUser.swift in Sources */,
+				2FA9C4EB256352AB00ACBD9D /* ApiResult.swift in Sources */,
 				6294D6EE1F72944F0064EBFA /* User.swift in Sources */,
 				6294D6E81F7279F90064EBFA /* BaseService.swift in Sources */,
+				2FA9C3ED255E0BCE00ACBD9D /* IngresseResponse.swift in Sources */,
 				69DDDDED22B012D800051883 /* AuthResponse.swift in Sources */,
 				6239BA121EC5FBA000C7BD16 /* GuestTicket.swift in Sources */,
 				6231F25020B744A900206D85 /* NewEvent.swift in Sources */,
@@ -1141,9 +1252,11 @@
 				750A814420E183F7004881C8 /* CompanyData.swift in Sources */,
 				62D6423521AC4C02002E1A39 /* ShopRequest.swift in Sources */,
 				2F74E12923C665AF004176E5 /* Disclaimer.swift in Sources */,
+				2FA9C3DD255DD2BE00ACBD9D /* WalletRequest.swift in Sources */,
 				62A708BB21068E3F0027F05E /* Poster.swift in Sources */,
 				75D531FD20EFA26A0046CC7E /* CheckinStatus.swift in Sources */,
 				6294D6EA1F7280E80064EBFA /* PendingTransfer.swift in Sources */,
+				2FA9C3E7255DD9FB00ACBD9D /* KeyedRequest.swift in Sources */,
 				623702311F72D413006A1335 /* Advertisement.swift in Sources */,
 				2F7D2F8D22EFAC2B00DD8E17 /* WalletInfoPaypal.swift in Sources */,
 				CEB19DF92469CBD50047CF3B /* WalletEventLive.swift in Sources */,
@@ -1175,9 +1288,12 @@
 				6245262A1EC2324F007B6584 /* Session.swift in Sources */,
 				355C19D621764F89004ABEBB /* TicketGroup.swift in Sources */,
 				6274856D1F05704F009AE812 /* TransactionSession.swift in Sources */,
+				2FA9C3E1255DD44F00ACBD9D /* UserWalletService.swift in Sources */,
 				62F7D1BC21CBD53B000F51FE /* AuthRequests.swift in Sources */,
+				2FA9C40B255F40D200ACBD9D /* UserWallet.swift in Sources */,
 				2F31EB9422F4A9FF001B6F6E /* UserCardRequests.swift in Sources */,
 				6246D6B61FD7086E0012FAD9 /* Planner.swift in Sources */,
+				2FA9C405255F3E5B00ACBD9D /* PagedResponse.swift in Sources */,
 				352A167E2110B1F300814AF9 /* Address.swift in Sources */,
 				627485651F054ACF009AE812 /* Refund.swift in Sources */,
 				6237022F1F72D1D8006A1335 /* EventAttributes.swift in Sources */,
@@ -1185,15 +1301,19 @@
 				627485691F056CD1009AE812 /* TransactionEvent.swift in Sources */,
 				627485671F054AF1009AE812 /* TransactionTicket.swift in Sources */,
 				62A708B721068CDE0027F05E /* Attributes.swift in Sources */,
+				2FA9C3D8255DC9B600ACBD9D /* UserWalletURLRequest.swift in Sources */,
 				598CD3FE2456478E00D16220 /* CashlessURLRequest.swift in Sources */,
 				2FEAF87E235A20CF0080D1BA /* PhoneService.swift in Sources */,
 				6284F8601ED7601E00E5FECF /* CheckinSyncDelegate.swift in Sources */,
+				2FA9C40F255F458500ACBD9D /* UserWallet+Extensions.swift in Sources */,
+				2FA9C3F8255E153000ACBD9D /* IngresseError.swift in Sources */,
 				6280CAC02108E6BE0075FACB /* UserEventsDownloaderDelegate.swift in Sources */,
 				6246D6B21FD6F56A0012FAD9 /* WalletSyncDelegate.swift in Sources */,
 				624526371EC23255007B6584 /* TicketSyncDelegate.swift in Sources */,
 				CE2D74FB2409CED800A799BA /* TransactionRequest.swift in Sources */,
 				6231F25220B744DA00206D85 /* NewEventSyncDelegate.swift in Sources */,
 				CEBABEF5243D2AF000C07518 /* Coupon.swift in Sources */,
+				2FA9C4F22563569500ACBD9D /* Errors.swift in Sources */,
 				598CD3F7245645AE00D16220 /* AuthenticationType.swift in Sources */,
 				62D18ACE1F1673DF00DC2270 /* TransferHistoryItem.swift in Sources */,
 				6239BA0E1EC5F76B00C7BD16 /* APIError.swift in Sources */,

--- a/IngresseSDK.xcodeproj/project.pbxproj
+++ b/IngresseSDK.xcodeproj/project.pbxproj
@@ -21,6 +21,14 @@
 		2F7D2F8B22EFA1AA00DD8E17 /* UserWalletInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7D2F8A22EFA1AA00DD8E17 /* UserWalletInfo.swift */; };
 		2F7D2F8D22EFAC2B00DD8E17 /* WalletInfoPaypal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7D2F8C22EFAC2B00DD8E17 /* WalletInfoPaypal.swift */; };
 		2F7D2F8F22EFAC8000DD8E17 /* WalletInfoCreditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7D2F8E22EFAC8000DD8E17 /* WalletInfoCreditCard.swift */; };
+		2F98023A256D691300E2F2E3 /* TransfersRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F980239256D691300E2F2E3 /* TransfersRequest.swift */; };
+		2F98023E256D7CC500E2F2E3 /* TicketTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F98023D256D7CC500E2F2E3 /* TicketTransfer.swift */; };
+		2F980261256DDB5600E2F2E3 /* TicketTransferURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F980260256DDB5600E2F2E3 /* TicketTransferURLRequest.swift */; };
+		2F980265256DDD2D00E2F2E3 /* TicketTransfer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F980264256DDD2D00E2F2E3 /* TicketTransfer+Extensions.swift */; };
+		2F980269256DDD7800E2F2E3 /* TicketTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F980268256DDD7800E2F2E3 /* TicketTransferService.swift */; };
+		2F980270256DE6DF00E2F2E3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F98026F256DE6DF00E2F2E3 /* HTTPMethod.swift */; };
+		2F980274256DE8AF00E2F2E3 /* UpdateTransferRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F980273256DE8AF00E2F2E3 /* UpdateTransferRequest.swift */; };
+		2F980278256DEC7000E2F2E3 /* UpdatedTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F980277256DEC7000E2F2E3 /* UpdatedTransfer.swift */; };
 		2FA9C3D8255DC9B600ACBD9D /* UserWalletURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3D7255DC9B600ACBD9D /* UserWalletURLRequest.swift */; };
 		2FA9C3DD255DD2BE00ACBD9D /* WalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3DC255DD2BE00ACBD9D /* WalletRequest.swift */; };
 		2FA9C3E1255DD44F00ACBD9D /* UserWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9C3E0255DD44F00ACBD9D /* UserWalletService.swift */; };
@@ -252,6 +260,14 @@
 		2F7D2F8A22EFA1AA00DD8E17 /* UserWalletInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletInfo.swift; sourceTree = "<group>"; };
 		2F7D2F8C22EFAC2B00DD8E17 /* WalletInfoPaypal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfoPaypal.swift; sourceTree = "<group>"; };
 		2F7D2F8E22EFAC8000DD8E17 /* WalletInfoCreditCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfoCreditCard.swift; sourceTree = "<group>"; };
+		2F980239256D691300E2F2E3 /* TransfersRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransfersRequest.swift; sourceTree = "<group>"; };
+		2F98023D256D7CC500E2F2E3 /* TicketTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketTransfer.swift; sourceTree = "<group>"; };
+		2F980260256DDB5600E2F2E3 /* TicketTransferURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketTransferURLRequest.swift; sourceTree = "<group>"; };
+		2F980264256DDD2D00E2F2E3 /* TicketTransfer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TicketTransfer+Extensions.swift"; sourceTree = "<group>"; };
+		2F980268256DDD7800E2F2E3 /* TicketTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketTransferService.swift; sourceTree = "<group>"; };
+		2F98026F256DE6DF00E2F2E3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		2F980273256DE8AF00E2F2E3 /* UpdateTransferRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateTransferRequest.swift; sourceTree = "<group>"; };
+		2F980277256DEC7000E2F2E3 /* UpdatedTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedTransfer.swift; sourceTree = "<group>"; };
 		2FA9C3D7255DC9B600ACBD9D /* UserWalletURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletURLRequest.swift; sourceTree = "<group>"; };
 		2FA9C3DC255DD2BE00ACBD9D /* WalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRequest.swift; sourceTree = "<group>"; };
 		2FA9C3E0255DD44F00ACBD9D /* UserWalletService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletService.swift; sourceTree = "<group>"; };
@@ -531,6 +547,44 @@
 			path = Header;
 			sourceTree = "<group>";
 		};
+		2F980234256D5D1200E2F2E3 /* TicketTransfer */ = {
+			isa = PBXGroup;
+			children = (
+				2F980236256D5D2600E2F2E3 /* Requests */,
+				2F980235256D5D1E00E2F2E3 /* Responses */,
+				2F980260256DDB5600E2F2E3 /* TicketTransferURLRequest.swift */,
+				2F980268256DDD7800E2F2E3 /* TicketTransferService.swift */,
+			);
+			path = TicketTransfer;
+			sourceTree = "<group>";
+		};
+		2F980235256D5D1E00E2F2E3 /* Responses */ = {
+			isa = PBXGroup;
+			children = (
+				2F98023D256D7CC500E2F2E3 /* TicketTransfer.swift */,
+				2F980264256DDD2D00E2F2E3 /* TicketTransfer+Extensions.swift */,
+				2F980277256DEC7000E2F2E3 /* UpdatedTransfer.swift */,
+			);
+			path = Responses;
+			sourceTree = "<group>";
+		};
+		2F980236256D5D2600E2F2E3 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				2F980239256D691300E2F2E3 /* TransfersRequest.swift */,
+				2F980273256DE8AF00E2F2E3 /* UpdateTransferRequest.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		2F98026E256DE6CD00E2F2E3 /* HTTPMethod */ = {
+			isa = PBXGroup;
+			children = (
+				2F98026F256DE6DF00E2F2E3 /* HTTPMethod.swift */,
+			);
+			path = HTTPMethod;
+			sourceTree = "<group>";
+		};
 		2FA9C3D6255DC57100ACBD9D /* UserWallet */ = {
 			isa = PBXGroup;
 			children = (
@@ -628,6 +682,7 @@
 		598CD3F0245645AE00D16220 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				2F98026E256DE6CD00E2F2E3 /* HTTPMethod */,
 				2F401AAD25658CFE001F09EF /* Header */,
 				2FA9C4F02563567F00ACBD9D /* Defaults */,
 				2FA9C4E92563528B00ACBD9D /* Parser */,
@@ -839,6 +894,7 @@
 		6245262D1EC23255007B6584 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				2F980234256D5D1200E2F2E3 /* TicketTransfer */,
 				2F401A8F256574CA001F09EF /* UserTickets */,
 				2FA9C3D6255DC57100ACBD9D /* UserWallet */,
 				352A167B2110A80900814AF9 /* AddressService.swift */,
@@ -1253,6 +1309,7 @@
 				6231F24720B7442200206D85 /* BackgroundAd.swift in Sources */,
 				624526341EC23255007B6584 /* IngresseService.swift in Sources */,
 				62BFE0711F72AB53007150ED /* SocialAccount.swift in Sources */,
+				2F980265256DDD2D00E2F2E3 /* TicketTransfer+Extensions.swift in Sources */,
 				750A814620E186D0004881C8 /* Company.swift in Sources */,
 				624526151EC2322C007B6584 /* SDKErrors.swift in Sources */,
 				352632392118B643003615F1 /* PaymentService.swift in Sources */,
@@ -1274,6 +1331,8 @@
 				355C19DA21765219004ABEBB /* TicketDate.swift in Sources */,
 				59D4E27F2464A2A200F64FB2 /* CashlessTokenEventResponse.swift in Sources */,
 				6231F24F20B744A900206D85 /* ElasticPagination.swift in Sources */,
+				2F980270256DE6DF00E2F2E3 /* HTTPMethod.swift in Sources */,
+				2F980278256DEC7000E2F2E3 /* UpdatedTransfer.swift in Sources */,
 				355C19D8217650AD004ABEBB /* Ticket.swift in Sources */,
 				2FC7448923D6291A000C1430 /* Insurance.swift in Sources */,
 				3561965F21FA4C6A00EE6DA3 /* UpdateUserRequests.swift in Sources */,
@@ -1314,6 +1373,7 @@
 				623702311F72D413006A1335 /* Advertisement.swift in Sources */,
 				2F7D2F8D22EFAC2B00DD8E17 /* WalletInfoPaypal.swift in Sources */,
 				CEB19DF92469CBD50047CF3B /* WalletEventLive.swift in Sources */,
+				2F98023A256D691300E2F2E3 /* TransfersRequest.swift in Sources */,
 				692A1A4C2280680100D9CDD1 /* SecurityService.swift in Sources */,
 				2F74E12523C65D24004176E5 /* PaymentTransaction.swift in Sources */,
 				6294D6EC1F728DD80064EBFA /* SearchService.swift in Sources */,
@@ -1324,6 +1384,7 @@
 				62A708B921068E1F0027F05E /* Place.swift in Sources */,
 				6245263C1EC2325D007B6584 /* URLBuilder.swift in Sources */,
 				627D85801FD5AD1300C98171 /* PaymentCard.swift in Sources */,
+				2F980274256DE8AF00E2F2E3 /* UpdateTransferRequest.swift in Sources */,
 				A53BEF152246ED8500155109 /* EventsResponse.swift in Sources */,
 				62E6EDE41F1FE23400F0B1E8 /* Venue.swift in Sources */,
 				CEEBC6E8246C4E0C00D87A81 /* Encodable+Dictionary.swift in Sources */,
@@ -1343,6 +1404,7 @@
 				355C19D621764F89004ABEBB /* TicketGroup.swift in Sources */,
 				6274856D1F05704F009AE812 /* TransactionSession.swift in Sources */,
 				2FA9C3E1255DD44F00ACBD9D /* UserWalletService.swift in Sources */,
+				2F980261256DDB5600E2F2E3 /* TicketTransferURLRequest.swift in Sources */,
 				62F7D1BC21CBD53B000F51FE /* AuthRequests.swift in Sources */,
 				2FA9C40B255F40D200ACBD9D /* UserWallet.swift in Sources */,
 				2F31EB9422F4A9FF001B6F6E /* UserCardRequests.swift in Sources */,
@@ -1356,6 +1418,7 @@
 				627485691F056CD1009AE812 /* TransactionEvent.swift in Sources */,
 				627485671F054AF1009AE812 /* TransactionTicket.swift in Sources */,
 				62A708B721068CDE0027F05E /* Attributes.swift in Sources */,
+				2F98023E256D7CC500E2F2E3 /* TicketTransfer.swift in Sources */,
 				2FA9C3D8255DC9B600ACBD9D /* UserWalletURLRequest.swift in Sources */,
 				598CD3FE2456478E00D16220 /* CashlessURLRequest.swift in Sources */,
 				2F401AB32565E7BC001F09EF /* UserWalletTicketService.swift in Sources */,
@@ -1370,6 +1433,7 @@
 				6231F25220B744DA00206D85 /* NewEventSyncDelegate.swift in Sources */,
 				CEBABEF5243D2AF000C07518 /* Coupon.swift in Sources */,
 				2FA9C4F22563569500ACBD9D /* Errors.swift in Sources */,
+				2F980269256DDD7800E2F2E3 /* TicketTransferService.swift in Sources */,
 				598CD3F7245645AE00D16220 /* AuthenticationType.swift in Sources */,
 				62D18ACE1F1673DF00DC2270 /* TransferHistoryItem.swift in Sources */,
 				6239BA0E1EC5F76B00C7BD16 /* APIError.swift in Sources */,

--- a/IngresseSDK.xcodeproj/project.pbxproj
+++ b/IngresseSDK.xcodeproj/project.pbxproj
@@ -10,6 +10,12 @@
 		0E9831B41F217135001211C6 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9831B31F217135001211C6 /* UserService.swift */; };
 		2F31EB9422F4A9FF001B6F6E /* UserCardRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F31EB9322F4A9FF001B6F6E /* UserCardRequests.swift */; };
 		2F31EB9622F4AF70001B6F6E /* UserCardWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F31EB9522F4AF70001B6F6E /* UserCardWalletService.swift */; };
+		2F401A932565761F001F09EF /* TicketsWalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F401A922565761F001F09EF /* TicketsWalletRequest.swift */; };
+		2F401A9925657775001F09EF /* UserWalletTicket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F401A9825657775001F09EF /* UserWalletTicket.swift */; };
+		2F401AA625657D97001F09EF /* UserWalletTicket+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F401AA525657D97001F09EF /* UserWalletTicket+Extensions.swift */; };
+		2F401AAA25657E33001F09EF /* UserWalletTicketURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F401AA925657E33001F09EF /* UserWalletTicketURLRequest.swift */; };
+		2F401AAF25658D0B001F09EF /* HeaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F401AAE25658D0B001F09EF /* HeaderType.swift */; };
+		2F401AB32565E7BC001F09EF /* UserWalletTicketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F401AB22565E7BC001F09EF /* UserWalletTicketService.swift */; };
 		2F74E12523C65D24004176E5 /* PaymentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F74E12423C65D24004176E5 /* PaymentTransaction.swift */; };
 		2F74E12923C665AF004176E5 /* Disclaimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F74E12823C665AF004176E5 /* Disclaimer.swift */; };
 		2F7D2F8B22EFA1AA00DD8E17 /* UserWalletInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7D2F8A22EFA1AA00DD8E17 /* UserWalletInfo.swift */; };
@@ -235,6 +241,12 @@
 		1C227B624464E57B6D3251DE /* Pods-IngresseSDK-IngresseSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IngresseSDK-IngresseSDKTests.release.xcconfig"; path = "Target Support Files/Pods-IngresseSDK-IngresseSDKTests/Pods-IngresseSDK-IngresseSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		2F31EB9322F4A9FF001B6F6E /* UserCardRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCardRequests.swift; sourceTree = "<group>"; };
 		2F31EB9522F4AF70001B6F6E /* UserCardWalletService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCardWalletService.swift; sourceTree = "<group>"; };
+		2F401A922565761F001F09EF /* TicketsWalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketsWalletRequest.swift; sourceTree = "<group>"; };
+		2F401A9825657775001F09EF /* UserWalletTicket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletTicket.swift; sourceTree = "<group>"; };
+		2F401AA525657D97001F09EF /* UserWalletTicket+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserWalletTicket+Extensions.swift"; sourceTree = "<group>"; };
+		2F401AA925657E33001F09EF /* UserWalletTicketURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletTicketURLRequest.swift; sourceTree = "<group>"; };
+		2F401AAE25658D0B001F09EF /* HeaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderType.swift; sourceTree = "<group>"; };
+		2F401AB22565E7BC001F09EF /* UserWalletTicketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletTicketService.swift; sourceTree = "<group>"; };
 		2F74E12423C65D24004176E5 /* PaymentTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentTransaction.swift; sourceTree = "<group>"; };
 		2F74E12823C665AF004176E5 /* Disclaimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Disclaimer.swift; sourceTree = "<group>"; };
 		2F7D2F8A22EFA1AA00DD8E17 /* UserWalletInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletInfo.swift; sourceTree = "<group>"; };
@@ -483,6 +495,42 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		2F401A8F256574CA001F09EF /* UserTickets */ = {
+			isa = PBXGroup;
+			children = (
+				2F401A91256574E6001F09EF /* Responses */,
+				2F401A90256574DC001F09EF /* Requests */,
+				2F401AA925657E33001F09EF /* UserWalletTicketURLRequest.swift */,
+				2F401AB22565E7BC001F09EF /* UserWalletTicketService.swift */,
+			);
+			path = UserTickets;
+			sourceTree = "<group>";
+		};
+		2F401A90256574DC001F09EF /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				2F401A922565761F001F09EF /* TicketsWalletRequest.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		2F401A91256574E6001F09EF /* Responses */ = {
+			isa = PBXGroup;
+			children = (
+				2F401A9825657775001F09EF /* UserWalletTicket.swift */,
+				2F401AA525657D97001F09EF /* UserWalletTicket+Extensions.swift */,
+			);
+			path = Responses;
+			sourceTree = "<group>";
+		};
+		2F401AAD25658CFE001F09EF /* Header */ = {
+			isa = PBXGroup;
+			children = (
+				2F401AAE25658D0B001F09EF /* HeaderType.swift */,
+			);
+			path = Header;
+			sourceTree = "<group>";
+		};
 		2FA9C3D6255DC57100ACBD9D /* UserWallet */ = {
 			isa = PBXGroup;
 			children = (
@@ -580,6 +628,7 @@
 		598CD3F0245645AE00D16220 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				2F401AAD25658CFE001F09EF /* Header */,
 				2FA9C4F02563567F00ACBD9D /* Defaults */,
 				2FA9C4E92563528B00ACBD9D /* Parser */,
 				2FA9C3FB255F108700ACBD9D /* Error */,
@@ -790,6 +839,7 @@
 		6245262D1EC23255007B6584 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				2F401A8F256574CA001F09EF /* UserTickets */,
 				2FA9C3D6255DC57100ACBD9D /* UserWallet */,
 				352A167B2110A80900814AF9 /* AddressService.swift */,
 				6245262E1EC23255007B6584 /* AuthService.swift */,
@@ -1183,6 +1233,7 @@
 			files = (
 				6294D6E61F7279E50064EBFA /* TransfersService.swift in Sources */,
 				622815931F20F4E800FD0D35 /* UserData.swift in Sources */,
+				2F401AA625657D97001F09EF /* UserWalletTicket+Extensions.swift in Sources */,
 				352A26B221A5900B0037E187 /* PaymentTicket.swift in Sources */,
 				A5982B142228BAF0004DEFC7 /* ProducerEventSyncDelegate.swift in Sources */,
 				6245262C1EC2324F007B6584 /* UserTicket.swift in Sources */,
@@ -1212,6 +1263,7 @@
 				62E134E11F20FBA70007B590 /* PaymentType.swift in Sources */,
 				6245261F1EC2323E007B6584 /* IngresseClient.swift in Sources */,
 				627485581F054776009AE812 /* TransactionService.swift in Sources */,
+				2F401AAF25658D0B001F09EF /* HeaderType.swift in Sources */,
 				624526201EC2323E007B6584 /* RestClient.swift in Sources */,
 				62A6250B1F8FF26700DD054F /* CustomTicket.swift in Sources */,
 				750A814820E1875D004881C8 /* CompanyLogo.swift in Sources */,
@@ -1246,6 +1298,7 @@
 				6239BA121EC5FBA000C7BD16 /* GuestTicket.swift in Sources */,
 				6231F25020B744A900206D85 /* NewEvent.swift in Sources */,
 				352A167C2110A80900814AF9 /* AddressService.swift in Sources */,
+				2F401AAA25657E33001F09EF /* UserWalletTicketURLRequest.swift in Sources */,
 				759406262100E98F00BA1BFB /* TransactionBasket.swift in Sources */,
 				694A2D2C23102C050024E2E3 /* WalletInfoHolder.swift in Sources */,
 				629BCF931EDF2F230043CBDE /* CheckinTicket.swift in Sources */,
@@ -1253,6 +1306,7 @@
 				62D6423521AC4C02002E1A39 /* ShopRequest.swift in Sources */,
 				2F74E12923C665AF004176E5 /* Disclaimer.swift in Sources */,
 				2FA9C3DD255DD2BE00ACBD9D /* WalletRequest.swift in Sources */,
+				2F401A932565761F001F09EF /* TicketsWalletRequest.swift in Sources */,
 				62A708BB21068E3F0027F05E /* Poster.swift in Sources */,
 				75D531FD20EFA26A0046CC7E /* CheckinStatus.swift in Sources */,
 				6294D6EA1F7280E80064EBFA /* PendingTransfer.swift in Sources */,
@@ -1294,6 +1348,7 @@
 				2F31EB9422F4A9FF001B6F6E /* UserCardRequests.swift in Sources */,
 				6246D6B61FD7086E0012FAD9 /* Planner.swift in Sources */,
 				2FA9C405255F3E5B00ACBD9D /* PagedResponse.swift in Sources */,
+				2F401A9925657775001F09EF /* UserWalletTicket.swift in Sources */,
 				352A167E2110B1F300814AF9 /* Address.swift in Sources */,
 				627485651F054ACF009AE812 /* Refund.swift in Sources */,
 				6237022F1F72D1D8006A1335 /* EventAttributes.swift in Sources */,
@@ -1303,6 +1358,7 @@
 				62A708B721068CDE0027F05E /* Attributes.swift in Sources */,
 				2FA9C3D8255DC9B600ACBD9D /* UserWalletURLRequest.swift in Sources */,
 				598CD3FE2456478E00D16220 /* CashlessURLRequest.swift in Sources */,
+				2F401AB32565E7BC001F09EF /* UserWalletTicketService.swift in Sources */,
 				2FEAF87E235A20CF0080D1BA /* PhoneService.swift in Sources */,
 				6284F8601ED7601E00E5FECF /* CheckinSyncDelegate.swift in Sources */,
 				2FA9C40F255F458500ACBD9D /* UserWallet+Extensions.swift in Sources */,

--- a/IngresseSDK/Base/Requests/KeyedRequest.swift
+++ b/IngresseSDK/Base/Requests/KeyedRequest.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct KeyedRequest<R: Encodable>: Encodable {
+    let request: R
+    let key: KeyRequest
+    
+    init(request: R,
+         apikey: String) {
+        
+        self.request = request
+        self.key = KeyRequest(apikey: apikey)
+    }
+    
+    init(request: R,
+         key: KeyRequest) {
+        
+        self.request = request
+        self.key = key
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        try request.encode(to: encoder)
+        try key.encode(to: encoder)
+    }
+    
+    public struct KeyRequest: Encodable {
+        
+        let apikey: String
+        
+        init(apikey: String) {
+            self.apikey = apikey
+        }
+    }
+}

--- a/IngresseSDK/Base/Responses/IngresseError.swift
+++ b/IngresseSDK/Base/Responses/IngresseError.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct IngresseError: Decodable {
+    let responseError: Self.ResponseError?
+    
+    struct ResponseError: Decodable {
+        let status: Bool?
+        let category: String?
+        let code: Int?
+        let message: String?
+    }
+}

--- a/IngresseSDK/Base/Responses/IngresseResponse.swift
+++ b/IngresseSDK/Base/Responses/IngresseResponse.swift
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+import Foundation
+
+public struct IngresseData<R: Decodable>: Decodable {
+    let responseData: R?
+}

--- a/IngresseSDK/Base/Responses/PagedResponse.swift
+++ b/IngresseSDK/Base/Responses/PagedResponse.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct PagedResponse<V: Decodable>: Decodable {
+    public let paginationInfo: Self.PaginationInfo?
+    public let data: [V]?
+    
+    public struct PaginationInfo: Decodable {
+        public let currentPage: Int
+        public let lastPage: Int
+        public let totalResults: Int
+        
+        public func isLastPage() -> Bool { currentPage >= lastPage }
+        public func nextPage() -> Int { currentPage + 1 }
+    }
+}

--- a/IngresseSDK/HTTPClient/IngresseClient.swift
+++ b/IngresseSDK/HTTPClient/IngresseClient.swift
@@ -6,17 +6,22 @@ public class IngresseClient: NSObject {
     var environment: Environment
     var apiKey: String
     var restClient: RestClientInterface
+    var userAgent: String
+    var authToken: String
     
     public init(apiKey: String,
                 userAgent: String,
-                authorization: String = "",
+                authToken: String,
                 env: Environment = .prod,
                 restClient: RestClientInterface? = nil) {
 
         self.apiKey = apiKey
         self.restClient = restClient ?? RestClient()
         self.environment = env
+        self.userAgent = userAgent
+        self.authToken = authToken
+
         UserAgent.header = userAgent
-        UserAgent.authorization = authorization
+        UserAgent.authorization = authToken
     }
 }

--- a/IngresseSDK/Network/Defaults/Errors.swift
+++ b/IngresseSDK/Network/Defaults/Errors.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+struct Errors {
+    
+    public struct Code6xxx {
+        public static let invalidToken = 6062
+        public static let expiredToken = 6065
+    }
+    
+    public struct Code2xxx {
+        public static let invalidToken = 2006
+    }
+    
+    public static let tokenError = [Code6xxx.invalidToken,
+                                    Code6xxx.expiredToken,
+                                    Code2xxx.invalidToken]
+}

--- a/IngresseSDK/Network/Error/ResponseError.swift
+++ b/IngresseSDK/Network/Error/ResponseError.swift
@@ -1,0 +1,58 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct ResponseError: Error {
+    public enum ErrorType {
+        case noData
+    }
+    
+    public let type: ErrorType?
+    public let code: Int?
+    public let message: String?
+    public let error: Error?
+    
+    public init(type: ErrorType?,
+                code: Int?,
+                message: String?,
+                error: Error?) {
+        
+        self.type = type
+        self.code = code
+        self.message = message
+        self.error = error
+    }
+    
+    public init(code: Int?,
+                message: String?,
+                error: Error?) {
+        
+        self.type = nil
+        self.code = code
+        self.message = message
+        self.error = error
+    }
+    
+    public init(code: Int?,
+                message: String?) {
+        
+        self.type = nil
+        self.code = code
+        self.message = message
+        self.error = nil
+    }
+    
+    public init(type: ErrorType) {
+        self.type = type
+        self.code = nil
+        self.message = nil
+        self.error = nil
+    }
+    
+    public init(error: Error) {
+        self.type = nil
+        self.code = nil
+        self.message = nil
+        self.error = error
+    }
+}

--- a/IngresseSDK/Network/HTTPMethod/HTTPMethod.swift
+++ b/IngresseSDK/Network/HTTPMethod/HTTPMethod.swift
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+import Alamofire
+
+extension HTTPMethod {
+    static let customPost = HTTPMethod(rawValue: "POST")
+}

--- a/IngresseSDK/Network/Header/HeaderType.swift
+++ b/IngresseSDK/Network/Header/HeaderType.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+enum HeaderType {
+
+    case userAgent(header: String, authorization: String)
+    case applicationJson
+
+    public var content: [String: String] {
+        switch self {
+        case let .userAgent(header, authorization):
+            return [header: authorization]
+        case .applicationJson:
+            return ["content-type": "application/json"]
+        }
+    }
+}

--- a/IngresseSDK/Network/Network.swift
+++ b/IngresseSDK/Network/Network.swift
@@ -12,8 +12,11 @@ struct Network {
 
     // MARK: - Cancel requests
 
-    static func cancelAllRequests() {
-        session.cancelAllRequests()
+    static func cancelAllRequests(_ completionQueue: DispatchQueue,
+                                  _ completion: (() -> Void)? = nil) {
+
+        session.cancelAllRequests(completingOnQueue: completionQueue,
+                                  completion: completion)
     }
 
     // MARK: - Default request

--- a/IngresseSDK/Network/Network.swift
+++ b/IngresseSDK/Network/Network.swift
@@ -9,7 +9,15 @@ struct Network {
     typealias CustomApiResult<U: Decodable> = ApiResult<U, ResponseError, ResponseError>
     
     private static let session = Alamofire.Session.default
-    
+
+    // MARK: - Cancel requests
+
+    static func cancelAllRequests() {
+        session.cancelAllRequests()
+    }
+
+    // MARK: - Default request
+
     static func request<U: Decodable>(_ networkURLRequest: NetworkURLRequest,
                                       completion: @escaping (Swift.Result<U, Error>) -> Void) {
         
@@ -40,11 +48,13 @@ struct Network {
                 }
             }
     }
-    
+
+    // MARK: - Ingresse api request
+
     static func apiRequest<U: Decodable>(queue: DispatchQueue,
                                          networkURLRequest: NetworkURLRequest,
                                          completion: @escaping (CustomApiResult<U>) -> Void) {
-        
+
         let urlRequest: URLRequestConvertible
         do {
             urlRequest = try networkURLRequest.asURLRequest()
@@ -52,7 +62,7 @@ struct Network {
             let failure = ResponseError(error: error)
             return completion(.failure(failure))
         }
-        
+
         session
             .request(urlRequest)
             .validate()

--- a/IngresseSDK/Network/Network.swift
+++ b/IngresseSDK/Network/Network.swift
@@ -5,12 +5,14 @@
 import Alamofire
 
 struct Network {
-
+    
+    typealias CustomApiResult<U: Decodable> = ApiResult<U, ResponseError, ResponseError>
+    
     private static let session = Alamofire.Session.default
-
+    
     static func request<U: Decodable>(_ networkURLRequest: NetworkURLRequest,
                                       completion: @escaping (Swift.Result<U, Error>) -> Void) {
-
+        
         let urlRequest: URLRequestConvertible
         do {
             urlRequest = try networkURLRequest.asURLRequest()
@@ -24,9 +26,12 @@ struct Network {
                 if let error = response.error {
                     return completion(.failure(error))
                 }
+                
                 guard let data = response.data, !data.isEmpty else {
-                    return completion(.failure(ResponseError.noData))
+                    let error = ResponseError(type: .noData)
+                    return completion(.failure(error))
                 }
+                
                 do {
                     let dataModel = try JSONDecoder().decode(U.self, from: data)
                     return completion(.success(dataModel))
@@ -35,9 +40,71 @@ struct Network {
                 }
             }
     }
+    
+    static func apiRequest<U: Decodable>(queue: DispatchQueue,
+                                         networkURLRequest: NetworkURLRequest,
+                                         completion: @escaping (CustomApiResult<U>) -> Void) {
+        let urlRequest: URLRequestConvertible
+        do {
+            urlRequest = try networkURLRequest.asURLRequest()
+        } catch {
+            let failure = ResponseError(error: error)
+            return completion(.failure(failure))
+        }
+        
+        session
+            .request(urlRequest)
+            
+            .response(
+                queue: queue,
+                completionHandler: { response in
+                    if let responseError = response.error {
+                        let error = ResponseError(error: responseError)
+                        return completion(.failure(error))
+                    }
+                    
+                    guard let data = response.data, !data.isEmpty else {
+                        let error = ResponseError(type: .noData)
+                        return completion(.failure(error))
+                    }
+                    
+                    if let errorData = try? JSONDecoder().decode(IngresseError.self, from: data),
+                       errorData.responseError != nil {
+                        let error = buildResponseError(errorData)
+                        
+                        if let code = error.code,
+                           Errors.tokenError.contains(code) {
+                            return completion(.userTokenError(error))
+                        }
+                        
+                        return completion(.failure(error))
+                    }
+                    
+                    do {
+                        let ingresseData = try JSONDecoder().decode(IngresseData<U>.self,
+                                                                    from: data)
+                        
+                        guard let data = ingresseData.responseData else {
+                            let error = ResponseError(type: .noData)
+                            return completion(.failure(error))
+                        }
+                        
+                        return completion(.success(data))
+                    } catch {
+                        let failure = ResponseError(error: error)
+                        return completion(.failure(failure))
+                    }
+                })
+    }
 }
 
-enum ResponseError: Error {
-
-    case noData
+private extension Network {
+    static func buildResponseError(_ response: IngresseError) -> ResponseError {
+        let errorCode = response.responseError?.code
+        let errorCategory = response.responseError?.category ?? ""
+        let errorMessage = response.responseError?.message ?? ""
+        
+        let message = "[\(errorCategory)] \(errorMessage)"
+        return ResponseError(code: errorCode, message: message)
+    }
 }

--- a/IngresseSDK/Network/Network.swift
+++ b/IngresseSDK/Network/Network.swift
@@ -44,6 +44,7 @@ struct Network {
     static func apiRequest<U: Decodable>(queue: DispatchQueue,
                                          networkURLRequest: NetworkURLRequest,
                                          completion: @escaping (CustomApiResult<U>) -> Void) {
+        
         let urlRequest: URLRequestConvertible
         do {
             urlRequest = try networkURLRequest.asURLRequest()
@@ -54,7 +55,7 @@ struct Network {
         
         session
             .request(urlRequest)
-            
+            .validate()
             .response(
                 queue: queue,
                 completionHandler: { response in

--- a/IngresseSDK/Network/NetworkURLRequest.swift
+++ b/IngresseSDK/Network/NetworkURLRequest.swift
@@ -10,6 +10,7 @@ protocol NetworkURLRequest {
     var path: String { get }
     var method: HTTPMethod { get }
     var parameters: Encodable? { get }
+    var body: Encodable? { get }
     var authenticationType: AuthenticationType? { get }
     var headers: [HeaderType]? { get }
 }
@@ -21,6 +22,8 @@ extension NetworkURLRequest {
         switch method {
         case .get, .delete:
             return URLEncoding.default
+        case .customPost:
+            return URLEncoding.queryString
         default:
             return JSONEncoding.default
         }
@@ -47,12 +50,27 @@ extension NetworkURLRequest {
         guard let url = baseURL?.appendingPathComponent(path) else {
             throw NetworkRequestError.invalidURL
         }
-        let urlRequest = try URLRequest(url: url, method: method, headers: headers)
+
+        var urlRequest = try URLRequest(url: url, method: method, headers: headers)
+
+        if method == .customPost {
+            let data = try serialize(body)
+            urlRequest.httpBody = data
+        }
+
         return try encoding.encode(urlRequest, with: parameters?.encoded)
+    }
+
+    private func serialize(_ value: Encodable?) throws -> Data {
+        guard let encodedBody: [String: Any] = value?.encoded else {
+            throw NetworkRequestError.bodyEncodingFailed
+        }
+        return try JSONSerialization.data(withJSONObject: encodedBody, options: [])
     }
 }
 
 enum NetworkRequestError: Error {
 
     case invalidURL
+    case bodyEncodingFailed
 }

--- a/IngresseSDK/Network/NetworkURLRequest.swift
+++ b/IngresseSDK/Network/NetworkURLRequest.swift
@@ -27,20 +27,19 @@ extension NetworkURLRequest {
     }
 
     private var headers: HTTPHeaders? {
-        var mergedDicts: [String: String]?
+        var headerList = headers?.compactMap({ $0.content })
 
         if let authType = authenticationType?.header {
-            mergedDicts?.merge(authType) { current, _ in current }
+            headerList?.append(authType)
         }
 
-        headers?
-            .compactMap({ $0.content })
-            .forEach({ content in
-                mergedDicts?.merge(content) { current, _ in current }
-            })
+        guard let tupleHeader: [(String, String)] = headerList?.flatMap({ $0 }) else {
+            return nil
+        }
 
-        guard let headers = mergedDicts else { return nil }
-        return HTTPHeaders(headers)
+        let mergedDicts = Dictionary(tupleHeader, uniquingKeysWith: +)
+
+        return HTTPHeaders(mergedDicts)
     }
 
     func asURLRequest() throws -> URLRequestConvertible {

--- a/IngresseSDK/Network/Parser/ApiResult.swift
+++ b/IngresseSDK/Network/Parser/ApiResult.swift
@@ -1,0 +1,10 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+@frozen public enum ApiResult<Success, Failure: Error, UserTokenError: Error> {
+    
+    case success(Success)
+    case failure(Failure)
+    case userTokenError(UserTokenError)
+}

--- a/IngresseSDK/Services/BaseService.swift
+++ b/IngresseSDK/Services/BaseService.swift
@@ -11,4 +11,8 @@ public class BaseService: NSObject {
     init(_ client: IngresseClient) {
         self.client = client
     }
+
+    public func cancelAllRequests() {
+        Network.cancelAllRequests()
+    }
 }

--- a/IngresseSDK/Services/BaseService.swift
+++ b/IngresseSDK/Services/BaseService.swift
@@ -12,7 +12,9 @@ public class BaseService: NSObject {
         self.client = client
     }
 
-    public func cancelAllRequests() {
-        Network.cancelAllRequests()
+    public func cancelAllRequests(completionQueue: DispatchQueue,
+                                  completion: (() -> Void)? = nil) {
+        
+        Network.cancelAllRequests(completionQueue, completion)
     }
 }

--- a/IngresseSDK/Services/Cashless/CashlessURLRequest.swift
+++ b/IngresseSDK/Services/Cashless/CashlessURLRequest.swift
@@ -17,6 +17,7 @@ struct CashlessURLRequest {
             self.environment = environment
         }
 
+        var body: Encodable? { nil }
         var baseURL: URL? { environment.cashlessBaseURL }
         var path: String { "token/\(eventId)" }
         var method: HTTPMethod { .get }

--- a/IngresseSDK/Services/Cashless/CashlessURLRequest.swift
+++ b/IngresseSDK/Services/Cashless/CashlessURLRequest.swift
@@ -21,8 +21,8 @@ struct CashlessURLRequest {
         var path: String { "token/\(eventId)" }
         var method: HTTPMethod { .get }
         var parameters: Encodable? { nil }
-
-        var authenticationType: AuthenticationType {
+        var headers: [HeaderType]? { nil }
+        var authenticationType: AuthenticationType? {
             .bearer(token: UserAgent.authorization)
         }
     }

--- a/IngresseSDK/Services/IngresseService.swift
+++ b/IngresseSDK/Services/IngresseService.swift
@@ -45,4 +45,6 @@ public class IngresseService: NSObject {
     public lazy var cashless = CashlessService(client)
     
     public lazy var userWallet = UserWalletService(client)
+
+    public lazy var userWalletTickets = UserWalletTicketService(client)
 }

--- a/IngresseSDK/Services/IngresseService.swift
+++ b/IngresseSDK/Services/IngresseService.swift
@@ -3,47 +3,47 @@
 //
 
 public class IngresseService: NSObject {
-    
+
     private let client: IngresseClient
-    
+
     public init(client: IngresseClient) {
-        
         self.client = client
     }
-    
+
     // Lazy vars, only created when needed
     public lazy var payment = PaymentService(client)
-    
+
     public lazy var address = AddressService(client)
-    
+
     @objc
+
     public lazy var auth = AuthService(client)
-    
+
     public lazy var user = UserService(client)
-    
+
     public lazy var userCardWallet = UserCardWalletService(client)
-    
+
     public lazy var event = EventService(client)
-    
+
     public lazy var entrance = EntranceService(client)
-    
+
     public lazy var myTickets = MyTicketsService(client)
-    
+
     @objc
     public lazy var transaction = TransactionService(client)
-    
+
     public lazy var transfers = TransfersService(client)
-    
+
     public lazy var search = SearchService(client)
-    
+
     public lazy var security = SecurityService(client)
-    
+
     public lazy var phone = PhoneService(client)
-    
+
     public lazy var liveEvent = LiveEventService(client)
-    
+
     public lazy var cashless = CashlessService(client)
-    
+
     public lazy var userWallet = UserWalletService(client)
 
     public lazy var userWalletTicket = UserWalletTicketService(client)

--- a/IngresseSDK/Services/IngresseService.swift
+++ b/IngresseSDK/Services/IngresseService.swift
@@ -47,4 +47,6 @@ public class IngresseService: NSObject {
     public lazy var userWallet = UserWalletService(client)
 
     public lazy var userWalletTicket = UserWalletTicketService(client)
+
+    public lazy var ticketTransfer = TicketTransferService(client)
 }

--- a/IngresseSDK/Services/IngresseService.swift
+++ b/IngresseSDK/Services/IngresseService.swift
@@ -46,5 +46,5 @@ public class IngresseService: NSObject {
     
     public lazy var userWallet = UserWalletService(client)
 
-    public lazy var userWalletTickets = UserWalletTicketService(client)
+    public lazy var userWalletTicket = UserWalletTicketService(client)
 }

--- a/IngresseSDK/Services/IngresseService.swift
+++ b/IngresseSDK/Services/IngresseService.swift
@@ -7,40 +7,42 @@ public class IngresseService: NSObject {
     private let client: IngresseClient
     
     public init(client: IngresseClient) {
-
+        
         self.client = client
     }
     
     // Lazy vars, only created when needed
     public lazy var payment = PaymentService(client)
-
+    
     public lazy var address = AddressService(client)
-
+    
     @objc
     public lazy var auth = AuthService(client)
     
     public lazy var user = UserService(client)
     
     public lazy var userCardWallet = UserCardWalletService(client)
-
+    
     public lazy var event = EventService(client)
-
+    
     public lazy var entrance = EntranceService(client)
     
     public lazy var myTickets = MyTicketsService(client)
-
+    
     @objc
     public lazy var transaction = TransactionService(client)
     
     public lazy var transfers = TransfersService(client)
-
+    
     public lazy var search = SearchService(client)
-
+    
     public lazy var security = SecurityService(client)
-
+    
     public lazy var phone = PhoneService(client)
-
+    
     public lazy var liveEvent = LiveEventService(client)
-
+    
     public lazy var cashless = CashlessService(client)
+    
+    public lazy var userWallet = UserWalletService(client)
 }

--- a/IngresseSDK/Services/TicketTransfer/Requests/TransfersRequest.swift
+++ b/IngresseSDK/Services/TicketTransfer/Requests/TransfersRequest.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct TransfersRequest: Encodable {
+
+    public let usertoken: String
+    public let status: String?
+    public let page: Int?
+    public let pageSize: Int?
+
+    public init(usertoken: String,
+                page: Int? = nil,
+                pageSize: Int? = nil) {
+
+        self.usertoken = usertoken
+        self.status = TransferStatus.pending.rawValue
+        self.page = page
+        self.pageSize = pageSize
+    }
+
+    public init(usertoken: String,
+                status: TransferStatus? = nil,
+                page: Int? = nil,
+                pageSize: Int? = nil) {
+
+        self.usertoken = usertoken
+        self.status = status?.rawValue
+        self.page = page
+        self.pageSize = pageSize
+    }
+
+    public init(usertoken: String,
+                status: String? = nil,
+                page: Int? = nil,
+                pageSize: Int? = nil) {
+
+        self.usertoken = usertoken
+        self.status = status
+        self.page = page
+        self.pageSize = pageSize
+    }
+
+    public enum TransferStatus: String {
+
+        case pending
+        case accepted
+    }
+}

--- a/IngresseSDK/Services/TicketTransfer/Requests/UpdateTransferRequest.swift
+++ b/IngresseSDK/Services/TicketTransfer/Requests/UpdateTransferRequest.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct UpdateTransferRequest: Encodable {
+
+    public let parameters: Self.Parameters
+    public let body: Self.Body
+
+    public init(usertoken: String,
+                action: Body.TransferAction) {
+
+        self.parameters = Parameters(usertoken: usertoken)
+
+        self.body = Body(action: action)
+    }
+
+    public struct Parameters: Encodable {
+
+        public let usertoken: String
+
+        public init(usertoken: String) {
+
+            self.usertoken = usertoken
+        }
+    }
+
+    public struct Body: Encodable {
+
+        public let action: String
+        
+        public init(action: TransferAction) {
+            self.action = action.rawValue
+        }
+
+        public enum TransferAction: String {
+            case accept
+            case refuse
+            case cancel
+        }
+    }
+}

--- a/IngresseSDK/Services/TicketTransfer/Responses/TicketTransfer+Extensions.swift
+++ b/IngresseSDK/Services/TicketTransfer/Responses/TicketTransfer+Extensions.swift
@@ -1,0 +1,80 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+extension TicketTransfer {
+
+    public struct Event: Decodable {
+        public let id: Int?
+        public let title: String?
+        public let type: String?
+        public let status: String?
+        public let saleEnabled: Bool?
+        public let link: String?
+        public let poster: String?
+    }
+
+    public struct Session: Decodable {
+        public let id: Int?
+        public let datetime: String?
+    }
+
+    public struct Venue: Decodable {
+        public let id: Int?
+        public let name: String?
+        public let street: String?
+        public let crossStreet: String?
+        public let zipCode: String?
+        public let city: String?
+        public let state: String?
+        public let country: String?
+        public let latitude: Double?
+        public let longitude: Double?
+        public let hidden: Bool?
+        public let complement: String?
+    }
+
+    public struct Ticket: Decodable {
+        public let id: Int?
+        public let guestTypeId: Int?
+        public let ticketTypeId: Int?
+        public let name: String?
+        public let type: String?
+        public let desc: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case guestTypeId
+            case ticketTypeId
+            case name
+            case type
+            case desc = "description"
+        }
+    }
+
+    public struct ReceivedFrom: Decodable {
+        public let transferId: Int?
+        public let userId: Int?
+        public let email: String?
+        public let name: String?
+        public let type: String?
+        public let status: String?
+        public let history: [Self.History]?
+        public let socialId: [Self.SocialAccount]?
+        public let picture: String?
+
+        public struct History: Decodable {
+            public let status: String?
+            public let creationDate: String?
+        }
+
+        public class SocialAccount: Decodable {
+            public let id: String?
+            public let network: String?
+        }
+    }
+
+    public struct Sessions: Decodable {
+        public let data: [TicketTransfer.Session]?
+    }
+}

--- a/IngresseSDK/Services/TicketTransfer/Responses/TicketTransfer.swift
+++ b/IngresseSDK/Services/TicketTransfer/Responses/TicketTransfer.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct TicketTransfer: Decodable {
+    public let id: Int
+    public let event: Self.Event?
+    public let session: Self.Session?
+    public let venue: Self.Venue?
+    public let ticket: Self.Ticket?
+    public let receivedFrom: Self.ReceivedFrom?
+    public let sessions: Self.Sessions?
+}

--- a/IngresseSDK/Services/TicketTransfer/Responses/UpdatedTransfer.swift
+++ b/IngresseSDK/Services/TicketTransfer/Responses/UpdatedTransfer.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct UpdatedTransfer: Decodable {
+
+    public let saleTicketId: Int?
+    public let user: Self.User?
+    public let id: Int?
+    public let status: String?
+
+    public struct User: Decodable {
+        public let id: Int?
+        public let email: String?
+        public let name: String?
+        public let type: String?
+        public let social: [Self.SocialAccount]?
+        public let picture: String?
+
+
+        public class SocialAccount: Decodable {
+            public let id: String?
+            public let network: String?
+        }
+    }
+}

--- a/IngresseSDK/Services/TicketTransfer/TicketTransferService.swift
+++ b/IngresseSDK/Services/TicketTransfer/TicketTransferService.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+import Foundation
+
+public class TicketTransferService: BaseService {
+
+    public typealias CustomApiResult<U: Decodable> = ApiResult<U, ResponseError, ResponseError>
+
+    public typealias TransfersResponse = PagedResponse<TicketTransfer>
+
+    public func getTransfers(userId: Int,
+                             request: TransfersRequest,
+                             queue: DispatchQueue,
+                             completion: @escaping (CustomApiResult<TransfersResponse>) -> Void) {
+
+        let urlRequest = TicketTransferURLRequest.GetTransfers(userId: userId,
+                                                               apiKey: client.apiKey,
+                                                               request: request,
+                                                               environment: client.environment,
+                                                               userAgent: client.userAgent,
+                                                               authToken: client.authToken)
+
+        Network.apiRequest(queue: queue,
+                           networkURLRequest: urlRequest,
+                           completion: completion)
+    }
+
+    public func updateTransfer(transferId: Int,
+                               ticketId: Int,
+                               request: UpdateTransferRequest,
+                               queue: DispatchQueue,
+                               completion: @escaping (CustomApiResult<UpdatedTransfer>) -> Void) {
+
+        let urlRequest = TicketTransferURLRequest.UpdateTransfer(apiKey: client.apiKey,
+                                                                 transferId: transferId,
+                                                                 ticketId: ticketId,
+                                                                 request: request,
+                                                                 environment: client.environment,
+                                                                 userAgent: client.userAgent,
+                                                                 authToken: client.authToken)
+
+        Network.apiRequest(queue: queue,
+                           networkURLRequest: urlRequest,
+                           completion: completion)
+    }
+}

--- a/IngresseSDK/Services/TicketTransfer/TicketTransferURLRequest.swift
+++ b/IngresseSDK/Services/TicketTransfer/TicketTransferURLRequest.swift
@@ -1,0 +1,92 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+import Alamofire
+
+struct TicketTransferURLRequest {
+
+    struct GetTransfers: NetworkURLRequest {
+
+        private let userId: Int
+        private let apiKey: String
+        private let request: TransfersRequest
+        private let environment: Environment
+        private let userAgent: String
+        private let authToken: String
+
+        init(userId: Int,
+             apiKey: String,
+             request: TransfersRequest,
+             environment: Environment,
+             userAgent: String,
+             authToken: String) {
+
+            self.userId = userId
+            self.apiKey = apiKey
+            self.request = request
+            self.environment = environment
+            self.userAgent = userAgent
+            self.authToken = authToken
+        }
+
+        var body: Encodable? { nil }
+        var baseURL: URL? { environment.transfersBaseURL  }
+        var path: String { "user/\(userId)/transfers" }
+        var method: HTTPMethod { .get }
+        var authenticationType: AuthenticationType? { nil }
+        var parameters: Encodable? {
+            KeyedRequest(request: request, apikey: apiKey)
+        }
+        var headers: [HeaderType]? {
+            [.userAgent(header: userAgent, authorization: authToken)]
+        }
+    }
+
+    struct UpdateTransfer: NetworkURLRequest {
+
+        private let apiKey: String
+        private let transferId: Int
+        private let ticketId: Int
+        private let request: UpdateTransferRequest
+        private let environment: Environment
+        private let userAgent: String
+        private let authToken: String
+
+        init(apiKey: String,
+             transferId: Int,
+             ticketId: Int,
+             request: UpdateTransferRequest,
+             environment: Environment,
+             userAgent: String,
+             authToken: String) {
+
+            self.apiKey = apiKey
+            self.transferId = transferId
+            self.ticketId = ticketId
+            self.request = request
+            self.environment = environment
+            self.userAgent = userAgent
+            self.authToken = authToken
+        }
+
+        var body: Encodable? { request.body }
+        var baseURL: URL? { environment.transfersBaseURL }
+        var method: HTTPMethod { .customPost }
+        var authenticationType: AuthenticationType? { nil }
+        var path: String { "ticket/\(ticketId)/transfer/\(transferId)" }
+        var parameters: Encodable? {
+            KeyedRequest(request: request.parameters, apikey: apiKey)
+        }
+        var headers: [HeaderType]? {
+            [.userAgent(header: userAgent, authorization: authToken),
+             .applicationJson]
+        }
+    }
+}
+
+private extension Environment {
+    var transfersBaseURL: URL? {
+        URL(string: "https://\(self.rawValue)\(Host.api.rawValue)")
+    }
+}

--- a/IngresseSDK/Services/UserTickets/Requests/TicketsWalletRequest.swift
+++ b/IngresseSDK/Services/UserTickets/Requests/TicketsWalletRequest.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct TicketsRequest: Encodable {
+
+    public let usertoken: String
+    public let evendId: Int?
+    public let page: Int?
+    public let pageSize: Int?
+
+    public init(usertoken: String,
+                eventId: Int?,
+                page: Int?,
+                pageSize: Int?) {
+
+        self.usertoken = usertoken
+        self.evendId = eventId
+        self.page = page
+        self.pageSize = pageSize
+    }
+
+    public init(usertoken: String,
+                page: Int?,
+                pageSize: Int?) {
+
+        self.usertoken = usertoken
+        self.evendId = nil
+        self.page = page
+        self.pageSize = pageSize
+    }
+}

--- a/IngresseSDK/Services/UserTickets/Requests/TicketsWalletRequest.swift
+++ b/IngresseSDK/Services/UserTickets/Requests/TicketsWalletRequest.swift
@@ -5,7 +5,7 @@
 public struct TicketsRequest: Encodable {
 
     public let usertoken: String
-    public let evendId: Int?
+    public let eventId: Int?
     public let page: Int?
     public let pageSize: Int?
 
@@ -15,7 +15,7 @@ public struct TicketsRequest: Encodable {
                 pageSize: Int?) {
 
         self.usertoken = usertoken
-        self.evendId = eventId
+        self.eventId = eventId
         self.page = page
         self.pageSize = pageSize
     }
@@ -25,7 +25,7 @@ public struct TicketsRequest: Encodable {
                 pageSize: Int?) {
 
         self.usertoken = usertoken
-        self.evendId = nil
+        self.eventId = nil
         self.page = page
         self.pageSize = pageSize
     }

--- a/IngresseSDK/Services/UserTickets/Requests/TicketsWalletRequest.swift
+++ b/IngresseSDK/Services/UserTickets/Requests/TicketsWalletRequest.swift
@@ -8,6 +8,8 @@ public struct TicketsRequest: Encodable {
     public let eventId: Int?
     public let page: Int?
     public let pageSize: Int?
+    public let sessionId: String?
+    public let itemType: String?
 
     public init(usertoken: String,
                 eventId: Int?,
@@ -18,6 +20,8 @@ public struct TicketsRequest: Encodable {
         self.eventId = eventId
         self.page = page
         self.pageSize = pageSize
+        self.sessionId = nil
+        self.itemType = nil
     }
 
     public init(usertoken: String,
@@ -28,5 +32,35 @@ public struct TicketsRequest: Encodable {
         self.eventId = nil
         self.page = page
         self.pageSize = pageSize
+        self.sessionId = nil
+        self.itemType = nil
+    }
+
+    public init(usertoken: String,
+                eventId: Int?,
+                page: Int?,
+                pageSize: Int?,
+                sessionId: String? = nil,
+                itemType: TicketType? = nil) {
+
+        self.usertoken = usertoken
+        self.eventId = eventId
+        self.page = page
+        self.pageSize = pageSize
+        self.sessionId = sessionId
+        self.itemType = itemType?.rawValue
+    }
+
+    public enum TicketType: String {
+        case ticket
+        case passport
+    }
+
+    public func getType(_ string: String) -> TicketType {
+        if string == TicketType.ticket.rawValue {
+            return TicketType.ticket
+        }
+
+        return TicketType.passport
     }
 }

--- a/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket+Extensions.swift
+++ b/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket+Extensions.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public extension UserWalletTicket {
+
+    struct Venue: Decodable {
+        public let id: Int?
+        public let city: String?
+        public let complement: String?
+        public let country: String?
+        public let crossStreet: String?
+        public let name: String?
+        public let state: String?
+        public let street: String?
+        public let zipCode: String?
+        public let hidden: Bool?
+        public let latitude: Double?
+        public let longitude: Double?
+    }
+
+    struct Live: Decodable {
+        public let id: String?
+        public let enabled: Bool?
+    }
+
+    struct Sessions: Decodable {
+        public let data: [Self.SessionData]?
+
+        public struct SessionData: Decodable {
+            public let id: Int?
+            public let datetime: String?
+        }
+    }
+
+    struct Transfer: Decodable {
+        public let transferId: Int?
+        public let userId: Int?
+        public let email: String?
+        public let name: String?
+        public let type: String?
+        public let status: String?
+        public let history: [Self.History]?
+        public let socialId: [Self.SocialId]?
+        public let picture: String?
+
+        public struct SocialId: Decodable {
+            public let id: String?
+            public let network: String?
+        }
+
+        public struct History: Decodable {
+            public let status: String?
+            public let creationDate: String?
+        }
+    }
+}

--- a/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
+++ b/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct UserWalletTicket: Decodable {
+    public let id: Int
+    public let guestTypeId: Int?
+    public let ticketTypeId: Int?
+    public let itemType: String?
+    public let price: String?
+    public let tax: Int?
+    public let sessions: Self.Sessions?
+    public let title: String?
+    public let type: String?
+    public let eventId: Int?
+    public let eventTitle: String?
+    public let eventVenue: Self.Venue?
+    public let transactionId: String?
+    public let desc: String?
+    public let sequence: String?
+    public let code: String?
+    public let checked: Bool?
+    public let receivedFrom: Self.Transfer?
+    public let transferredTo: Self.Transfer?
+    public let currentHolder: Self.Transfer?
+    public let live: Self.Live?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case guestTypeId
+        case ticketTypeId
+        case itemType
+        case price
+        case tax
+        case sessions
+        case title
+        case type
+        case eventId
+        case eventTitle
+        case eventVenue
+        case transactionId
+        case desc = "description"
+        case sequence
+        case code
+        case checked
+        case receivedFrom
+        case transferredTo = "transferedTo"
+        case currentHolder
+        case live
+    }
+}

--- a/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
+++ b/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
@@ -8,7 +8,7 @@ public struct UserWalletTicket: Decodable {
     public let ticketTypeId: Int?
     public let itemType: String?
     public let price: Double?
-    public let tax: Int?
+    public let tax: Double?
     public let sessions: Self.Sessions?
     public let title: String?
     public let type: String?

--- a/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
+++ b/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
@@ -7,7 +7,7 @@ public struct UserWalletTicket: Decodable {
     public let guestTypeId: Int?
     public let ticketTypeId: Int?
     public let itemType: String?
-    public let price: String?
+    public let price: Double?
     public let tax: Int?
     public let sessions: Self.Sessions?
     public let title: String?

--- a/IngresseSDK/Services/UserTickets/UserWalletTicketService.swift
+++ b/IngresseSDK/Services/UserTickets/UserWalletTicketService.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+import Foundation
+
+public class UserWalletTicketService: BaseService {
+
+    public typealias CustomApiResult<U: Decodable> = ApiResult<U, ResponseError, ResponseError>
+
+    public typealias TicketResponse = PagedResponse<UserWalletTicket>
+
+    public func getTickets(userId: Int,
+                           request: TicketsRequest,
+                           queue: DispatchQueue,
+                           completion: @escaping (CustomApiResult<TicketResponse>) -> Void) {
+
+        let urlRequest = UserWalletTicketURLRequest.GetTickets(userId: userId,
+                                                               apiKey: client.apiKey,
+                                                               request: request,
+                                                               environment: client.environment,
+                                                               userAgent: client.userAgent,
+                                                               authToken: client.authToken)
+
+        Network.apiRequest(queue: queue,
+                           networkURLRequest: urlRequest,
+                           completion: completion)
+    }
+}

--- a/IngresseSDK/Services/UserTickets/UserWalletTicketURLRequest.swift
+++ b/IngresseSDK/Services/UserTickets/UserWalletTicketURLRequest.swift
@@ -4,20 +4,20 @@
 
 import Alamofire
 
-struct UserWalletURLRequest {
-    
-    struct GetWallet: NetworkURLRequest {
+struct UserWalletTicketURLRequest {
+
+    struct GetTickets: NetworkURLRequest {
 
         private let userId: Int
         private let apiKey: String
-        private let request: WalletRequest
+        private let request: TicketsRequest
         private let environment: Environment
         private let userAgent: String
         private let authToken: String
-        
+
         init(userId: Int,
              apiKey: String,
-             request: WalletRequest,
+             request: TicketsRequest,
              environment: Environment,
              userAgent: String,
              authToken: String) {
@@ -29,11 +29,11 @@ struct UserWalletURLRequest {
             self.userAgent = userAgent
             self.authToken = authToken
         }
-        
-        var baseURL: URL? { environment.walletBaseURL }
-        var path: String { "user/\(userId)/wallet" }
+
+        var baseURL: URL? { environment.ticketBaseURL }
+        var path: String { "user/\(userId)/tickets" }
         var method: HTTPMethod { .get }
-        var authenticationType: AuthenticationType? { nil}
+        var authenticationType: AuthenticationType? { nil }
         var headers: [HeaderType]? {
             [.userAgent(header: userAgent, authorization: authToken)]
         }
@@ -44,7 +44,7 @@ struct UserWalletURLRequest {
 }
 
 private extension Environment {
-    var walletBaseURL: URL? {
+    var ticketBaseURL: URL? {
         URL(string: "https://\(self.rawValue)\(Host.api.rawValue)")
     }
 }

--- a/IngresseSDK/Services/UserTickets/UserWalletTicketURLRequest.swift
+++ b/IngresseSDK/Services/UserTickets/UserWalletTicketURLRequest.swift
@@ -30,6 +30,7 @@ struct UserWalletTicketURLRequest {
             self.authToken = authToken
         }
 
+        var body: Encodable? { nil }
         var baseURL: URL? { environment.ticketBaseURL }
         var path: String { "user/\(userId)/tickets" }
         var method: HTTPMethod { .get }

--- a/IngresseSDK/Services/UserWallet/Requests/WalletRequest.swift
+++ b/IngresseSDK/Services/UserWallet/Requests/WalletRequest.swift
@@ -1,0 +1,87 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct WalletRequest: Encodable {
+    
+    public let usertoken: String
+    public let from: String?
+    public let to: String?
+    public let order: String?
+    public let page: Int?
+    public let pageSize: Int?
+    
+    public init(usertoken: String,
+                page: Int,
+                pageSize: Int,
+                ordenation: WalletOrdenation) {
+        
+        self.usertoken = usertoken
+        self.from = ordenation.from
+        self.to = ordenation.to
+        self.order = ordenation.order
+        self.page = page
+        self.pageSize = pageSize
+    }
+    
+    public init(usertoken: String,
+                from: String?,
+                to: String?,
+                order: String?,
+                page: Int?,
+                pageSize: Int?) {
+        
+        self.usertoken = usertoken
+        self.from = from
+        self.to = to
+        self.order = order
+        self.page = page
+        self.pageSize = pageSize
+    }
+    
+    public func getOrdenation() -> WalletOrdenation {
+        if from == .yesterday {
+            return WalletOrdenation.future
+        }
+        
+        if to == .yesterday {
+            return WalletOrdenation.past
+        }
+        
+        return WalletOrdenation.none
+    }
+    
+    public enum WalletOrdenation {
+        case future
+        case past
+        case none
+        
+        public var from: String? {
+            switch self {
+            case .future: return .yesterday
+            default: return nil
+            }
+        }
+        
+        public var to: String? {
+            switch self {
+            case .past: return .yesterday
+            default: return nil
+            }
+        }
+        
+        public var order: String? {
+            switch self {
+            case .future: return .ascending
+            case .past: return .descending
+            default: return nil
+            }
+        }
+    }
+}
+
+private extension String {
+    static let yesterday = "yesterday"
+    static let ascending = "ASC"
+    static let descending = "DESC"
+}

--- a/IngresseSDK/Services/UserWallet/Responses/UserWallet+Extensions.swift
+++ b/IngresseSDK/Services/UserWallet/Responses/UserWallet+Extensions.swift
@@ -13,10 +13,10 @@ public extension UserWallet {
         public let mobile: Self.Mobile?
         
         public struct Mobile: Decodable {
-            public let background: Self.MobileBackground?
+            public let background: Self.Background?
             public let cover: Self.Cover?
             
-            public struct MobileBackground: Decodable {
+            public struct Background: Decodable {
                 public let image: String?
             }
             

--- a/IngresseSDK/Services/UserWallet/Responses/UserWallet+Extensions.swift
+++ b/IngresseSDK/Services/UserWallet/Responses/UserWallet+Extensions.swift
@@ -1,0 +1,63 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public extension UserWallet {
+    
+    struct Live: Decodable {
+        public let id: String?
+        public let enabled: Bool?
+    }
+    
+    struct Advertisement: Decodable {
+        public let mobile: Self.Mobile?
+        
+        public struct Mobile: Decodable {
+            public let background: Self.MobileBackground?
+            public let cover: Self.Cover?
+            
+            public struct MobileBackground: Decodable {
+                public let image: String?
+            }
+            
+            public struct Cover: Decodable {
+                public let image: String?
+                public let url: String?
+            }
+        }
+    }
+    
+    struct Cashless: Decodable {
+        public let enabled: Bool?
+    }
+    
+    struct Sessions: Decodable {
+        public let data: [Self.SessionData]?
+        
+        public struct SessionData: Decodable {
+            public let id: Int?
+            public let datetime: String?
+        }
+    }
+    
+    struct CustomSessions: Decodable {
+        public let name: String?
+        public let slug: String?
+        public let status: String?
+    }
+    
+    struct Venue: Decodable {
+        public let id: Int?
+        public let city: String?
+        public let complement: String?
+        public let country: String?
+        public let crossStreet: String?
+        public let name: String?
+        public let state: String?
+        public let street: String?
+        public let zipCode: String?
+        public let hidden: Bool?
+        public let latitude: Double?
+        public let longitude: Double?
+    }
+}

--- a/IngresseSDK/Services/UserWallet/Responses/UserWallet.swift
+++ b/IngresseSDK/Services/UserWallet/Responses/UserWallet.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+public struct UserWallet: Decodable {
+    public let id: Int
+    public let ownerId: Int?
+    public let title: String?
+    public let desc: String?
+    public let type: String?
+    public let link: String?
+    public let poster: String?
+    public let tickets: Int?
+    public let transferred: Int?
+    public let customTickets: [Self.CustomSessions]?
+    public let advertisement: Self.Advertisement?
+    public let live: Self.Live?
+    public let cashless: Self.Cashless?
+    public let sessions: Self.Sessions?
+    public let venue: Self.Venue?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case ownerId
+        case title
+        case desc = "description"
+        case type
+        case link
+        case poster
+        case tickets
+        case transferred = "transfered"
+        case customTickets
+        case advertisement
+        case live
+        case cashless
+        case sessions
+        case venue
+    }
+}

--- a/IngresseSDK/Services/UserWallet/UserWalletService.swift
+++ b/IngresseSDK/Services/UserWallet/UserWalletService.swift
@@ -18,7 +18,9 @@ public class UserWalletService: BaseService {
         let urlRequest = UserWalletURLRequest.GetWallet(userId: userId,
                                                         apiKey: client.apiKey,
                                                         request: request,
-                                                        environment: client.environment)
+                                                        environment: client.environment,
+                                                        userAgent: client.userAgent,
+                                                        authToken: client.authToken)
         
         Network.apiRequest(queue: queue,
                            networkURLRequest: urlRequest,

--- a/IngresseSDK/Services/UserWallet/UserWalletService.swift
+++ b/IngresseSDK/Services/UserWallet/UserWalletService.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+import Foundation
+
+public class UserWalletService: BaseService {
+    
+    public typealias CustomApiResult<U: Decodable> = ApiResult<U, ResponseError, ResponseError>
+    
+    public typealias WalletResponse = PagedResponse<UserWallet>
+    
+    public func getWallet(userId: Int,
+                          request: WalletRequest,
+                          queue: DispatchQueue,
+                          completion: @escaping (CustomApiResult<WalletResponse>) -> Void) {
+        
+        let urlRequest = UserWalletURLRequest.GetWallet(userId: userId,
+                                                        apiKey: client.apiKey,
+                                                        request: request,
+                                                        environment: client.environment)
+        
+        Network.apiRequest(queue: queue,
+                           networkURLRequest: urlRequest,
+                           completion: completion)
+    }
+}

--- a/IngresseSDK/Services/UserWallet/UserWalletURLRequest.swift
+++ b/IngresseSDK/Services/UserWallet/UserWalletURLRequest.swift
@@ -1,0 +1,41 @@
+//
+//  Copyright © 2020 Ingresse. All rights reserved.
+//
+
+import Alamofire
+
+struct UserWalletURLRequest {
+    
+    struct GetWallet: NetworkURLRequest {
+        
+        private let userId: Int
+        private let apiKey: String
+        private let request: WalletRequest
+        private let environment: Environment
+        
+        init(userId: Int,
+             apiKey: String,
+             request: WalletRequest,
+             environment: Environment) {
+            self.userId = userId
+            self.apiKey = apiKey
+            self.request = request
+            self.environment = environment
+        }
+        
+        var baseURL: URL? { environment.walletBaseURL }
+        var path: String { "user/\(userId)/wallet" }
+        var method: HTTPMethod { .get }
+        var authenticationType: AuthenticationType { .bearer(token: "") }
+        var parameters: Encodable? {
+            KeyedRequest(request: request,
+                         apikey: apiKey)
+        }
+    }
+}
+
+private extension Environment {
+    var walletBaseURL: URL? {
+        URL(string: "https://\(self.rawValue)\(Host.api.rawValue)")
+    }
+}

--- a/IngresseSDK/Services/UserWallet/UserWalletURLRequest.swift
+++ b/IngresseSDK/Services/UserWallet/UserWalletURLRequest.swift
@@ -29,7 +29,8 @@ struct UserWalletURLRequest {
             self.userAgent = userAgent
             self.authToken = authToken
         }
-        
+
+        var body: Encodable? { nil }
         var baseURL: URL? { environment.walletBaseURL }
         var path: String { "user/\(userId)/wallet" }
         var method: HTTPMethod { .get }


### PR DESCRIPTION
## Contexto:
Com o bug encontrado na carteira do usuário onde os tickets futuros não estavam sendos salvos na carteira, fazendo-a parar de funcionar no modo offline, optamos pela utilização do novo esquema do SDK (Alamofire) para realizar todos as chamadas relativas a carteira.

### Issue: https://ingresse.atlassian.net/browse/DEV-72

## O que foi feito:
Adicionamos as chamadas da carteira (eventos), tickets, transferências pendentes e recusa ou aceite de ingressos. Com essas mudanças foi necessário realizar algumas modificações, tal como incluir um parser específico para o JSON da _api-ingresse_ e novos campos como **body** e **header**.