### PR TITLE
Reembolso de transações: adição do campo saleChanel

### DIFF
--- a/IngresseSDK/Model/TransactionData.swift
+++ b/IngresseSDK/Model/TransactionData.swift
@@ -19,6 +19,7 @@ public class TransactionData: NSObject, Decodable {
     @objc public var totalPaid: Double = 0
     @objc public var sumUp: Double = 0
     @objc public var paymentTax: Double = 0
+    @objc public var saleChannel: String? = ""
 
     @objc public var interest: Int = 0
     @objc public var taxToCostumer: Int = 0
@@ -65,6 +66,7 @@ public class TransactionData: NSObject, Decodable {
         case totalPaid
         case sumUp = "sum_up"
         case paymentTax
+        case saleChannel
         case interest
         case taxToCostumer
         case installments
@@ -98,6 +100,7 @@ public class TransactionData: NSObject, Decodable {
         totalPaid = container.decodeKey(.totalPaid, ofType: Double.self)
         sumUp = container.decodeKey(.sumUp, ofType: Double.self)
         paymentTax = container.decodeKey(.paymentTax, ofType: Double.self)
+        saleChannel = container.decodeKey(.saleChannel, ofType: String.self)
         interest = container.decodeKey(.interest, ofType: Int.self)
         taxToCostumer = container.decodeKey(.taxToCostumer, ofType: Int.self)
         installments = container.decodeKey(.installments, ofType: Int.self)


### PR DESCRIPTION
## Contexto:
Conforme conversado anteriormente com a equipe, decidimos liberar o acesso ao reembolso de transações somente quando a venda for to tipo offline e que o usuário tenha as devidas permissões necessárias para realizar o reembolso.

## O que foi feito:
Acrescentamos o atributo saleChanel no objeto de transações, para com ele, definirmos as regras na aplicação.