### PR TITLE
[Feature] Adição do atributo transferable na carteira de tickets do usuário

### DIFF
--- a/IngresseSDK/Model/UserTicket.swift
+++ b/IngresseSDK/Model/UserTicket.swift
@@ -24,6 +24,7 @@ public class UserTicket: NSObject, Codable {
     public var eventTitle: String = ""
     public var eventVenue: Venue?
     public var live: WalletEventLive = WalletEventLive()
+    public var transferable: Bool = false
     
     public var receivedFrom: Transfer?
     public var transferedTo: Transfer?
@@ -49,6 +50,7 @@ public class UserTicket: NSObject, Codable {
         case eventTitle
         case eventVenue
         case live
+        case transferable
         case receivedFrom
         case transferedTo
         case currentHolder
@@ -78,6 +80,7 @@ public class UserTicket: NSObject, Codable {
         eventTitle = container.decodeKey(.eventTitle, ofType: String.self)
         eventVenue = container.safeDecodeKey(.eventVenue, to: Venue.self)
         live = try container.decodeIfPresent(WalletEventLive.self, forKey: .live) ?? WalletEventLive()
+        transferable = container.decodeKey(.transferable, ofType: Bool.self)
         receivedFrom = container.safeDecodeKey(.receivedFrom, to: Transfer.self)
         transferedTo = container.safeDecodeKey(.transferedTo, to: Transfer.self)
         currentHolder = container.safeDecodeKey(.currentHolder, to: Transfer.self)

--- a/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
+++ b/IngresseSDK/Services/UserTickets/Responses/UserWalletTicket.swift
@@ -24,6 +24,7 @@ public struct UserWalletTicket: Decodable {
     public let transferredTo: Self.Transfer?
     public let currentHolder: Self.Transfer?
     public let live: Self.Live?
+    public let transferable: Bool?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -47,5 +48,6 @@ public struct UserWalletTicket: Decodable {
         case transferredTo = "transferedTo"
         case currentHolder
         case live
+        case transferable
     }
 }


### PR DESCRIPTION
## Contexto:
Para saber se um ingresso é vendível, devemos observar o atributo _transferable_ que vem na chamada de tickets do usuário na carteira.

### O que foi feito:
- Adição do atributo "transferable" no request antigo da carteira de tickets;
- Adição do atributo "transferable" no request novo da carteira de tickets;
