### PR TITLE
[Feature] Adição do campo birthdate nas chamadas relativas ao usuário

### DIFF
--- a/IngresseSDK/Errors/SDKErrors.swift
+++ b/IngresseSDK/Errors/SDKErrors.swift
@@ -27,6 +27,7 @@ public class SDKErrors: NSObject {
         1145: "O campo TELEFONE é necessário.",
         1144: "A senha deve conter 8 caracteres e ao menos uma letra.",
         1146: "O campo TELEFONE é inválido.",
+        1172: "O campo DATA DE NASCIMENTO é inválido.",
         2006: "Por favor, refaça a operação de login e tente novamente. Caso o erro persista, atualize o aplicativo.",
         2012: "Verifique em seu aparelho se as configurações de data e hora estão em \"ajuste automático\" e tente novamente.",
         3027: "Por favor, refaça a operação de login e tente novamente.",

--- a/IngresseSDK/Model/Requests/AuthRequests.swift
+++ b/IngresseSDK/Model/Requests/AuthRequests.swift
@@ -9,6 +9,7 @@ extension Request {
             public var ddi: String = ""
             public var phone: String = ""
             public var email: String = ""
+            public var birthdate: String? = ""
             public var document: String = ""
             public var password: String = ""
             public var token: String?
@@ -23,6 +24,7 @@ extension Request {
                 case ddi
                 case phone
                 case email
+                case birthdate
                 case document = "cpf"
                 case password
                 case token

--- a/IngresseSDK/Model/Requests/UpdateUserRequests.swift
+++ b/IngresseSDK/Model/Requests/UpdateUserRequests.swift
@@ -13,6 +13,7 @@ extension Request {
             public var ddi: String?
             public var phone: String?
             public var cpf: String?
+            public var birthdate: String?
             
             public init() {}
             
@@ -23,6 +24,7 @@ extension Request {
                 case ddi
                 case phone
                 case cpf
+                case birthdate
             }
         }
         

--- a/IngresseSDK/Model/UpdatedUser.swift
+++ b/IngresseSDK/Model/UpdatedUser.swift
@@ -11,6 +11,7 @@ public class UpdatedUser: NSObject, Decodable {
     public var email: String = ""
     public var cpf: String = ""
     public var name: String = ""
+    public var birthdate: String = ""
 
     enum CodingKeys: String, CodingKey {
         case ddi
@@ -21,6 +22,7 @@ public class UpdatedUser: NSObject, Decodable {
         case email
         case cpf
         case name
+        case birthdate
     }
 
     public override init() {}
@@ -35,5 +37,6 @@ public class UpdatedUser: NSObject, Decodable {
         email = container.decodeKey(.email, ofType: String.self)
         cpf = container.decodeKey(.cpf, ofType: String.self)
         name = container.decodeKey(.name, ofType: String.self)
+        birthdate = container.decodeKey(.birthdate, ofType: String.self)
     }
 }

--- a/IngresseSDK/Model/UserData.swift
+++ b/IngresseSDK/Model/UserData.swift
@@ -16,6 +16,7 @@ public class UserData: NSObject, Codable {
     public var ddi: String = ""
     public var phone: String = ""
     public var number: String = ""
+    public var birthdate: String = ""
     public var fbUserId: String = ""
     public var verified: Bool = false
     public var type: String = ""
@@ -36,6 +37,7 @@ public class UserData: NSObject, Codable {
         case ddi
         case phone
         case number
+        case birthdate
         case fbUserId
         case verified
         case type
@@ -58,6 +60,7 @@ public class UserData: NSObject, Codable {
         ddi = container.decodeKey(.ddi, ofType: String.self)
         phone = container.decodeKey(.phone, ofType: String.self)
         number = container.decodeKey(.number, ofType: String.self)
+        birthdate = container.decodeKey(.birthdate, ofType: String.self)
         fbUserId = container.decodeKey(.fbUserId, ofType: String.self)
         verified = container.decodeKey(.verified, ofType: Bool.self)
         type = container.decodeKey(.type, ofType: String.self)

--- a/IngresseSDK/Services/AuthService.swift
+++ b/IngresseSDK/Services/AuthService.swift
@@ -232,7 +232,7 @@ public class AuthService: BaseService {
             "id", "name", "lastname", "document", "email",
             "zip", "number", "complement", "city", "state",
             "street", "district", "ddi", "phone", "verified",
-            "fbUserId", "type", "pictures", "picture"]
+            "fbUserId", "type", "pictures", "picture", "birthdate"]
         let fieldsValue = fields ?? fieldsArray.joined(separator: ",")
 
         let builder = URLBuilder(client: client)


### PR DESCRIPTION
## Contexto:
Agora trataremos a data de nascimento do usuário no envio de criação de conta, atualização e ao obter dados do usuário.

### O que foi feito:
- Adição do campo `birthdate` no objeto de resposta do `getUserData`
- Adição do campo `birthdate` no objeto de resposta do `updateBasicInfos`
- Adição do campo `birthdate` no objeto de resposta do `createAccount`